### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Docker metadata
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242
         id: meta
         with:
           images: ghcr.io/chronicleprotocol/challenger-go
@@ -31,25 +31,25 @@ jobs:
             type=sha
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@e9a73d053822dd261763972e27a1731c06462d91
         with:
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55
         id: buildx
         with:
           install: true
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           fetch-depth: '0'
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495
         with:
           go-version: ${{ matrix.go-version }}
       - name: Linting Code
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
           version: v1.64
           args: --timeout=10m0s


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/docker.yml:19` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/docker.yml:22` `docker/metadata-action@v3` -> `docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242`
- `.github/workflows/docker.yml:34` `docker/setup-qemu-action@master` -> `docker/setup-qemu-action@e9a73d053822dd261763972e27a1731c06462d91`
- `.github/workflows/docker.yml:39` `docker/setup-buildx-action@v2` -> `docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55`
- `.github/workflows/docker.yml:45` `docker/login-action@v2` -> `docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc`
- `.github/workflows/docker.yml:52` `docker/build-push-action@v4` -> `docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9`
- `.github/workflows/tests.yml:20` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/tests.yml:24` `actions/setup-go@v3` -> `actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495`
- `.github/workflows/tests.yml:28` `golangci/golangci-lint-action@v6` -> `golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84`