### PR TITLE
ci: use central release image signing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,52 +12,9 @@ jobs:
   build-and-push:
     permissions:
       contents: read
+      id-token: write
       packages: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-
-      - name: Docker metadata
-        uses: docker/metadata-action@b2391d37b4157fa4aa2e118d643f417910ff3242
-        id: meta
-        with:
-          images: ghcr.io/chronicleprotocol/challenger-go
-          tags: |
-            type=raw,value=${{ inputs.version }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@e9a73d053822dd261763972e27a1731c06462d91
-        with:
-          platforms: all
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55
-        id: buildx
-        with:
-          install: true
-
-      - name: Login to Github Packages
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push
-        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9
-        with:
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            APP_VERSION=${{ inputs.version != '' && inputs.version || steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    uses: chronicleprotocol/actions-workflows/.github/workflows/docker-build-and-publish.yaml@main
+    with:
+      application: challenger-go
+      version: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Wire this repo image publishing workflow into the shared RFC-044.3 release image signing path.
- Use the central Docker builder or signer from `chronicleprotocol/actions-workflows`.
- Keep signing release-only on tag paths and preserve existing build inputs/tags.

## Verification
- `actionlint` on changed workflow file(s)
- `git diff --check origin/main`
- Local pre-push hooks were allowed to run; any failures were unrelated repo test/setup failures, not workflow syntax.