### PR TITLE
ci: self-contained build + sign for challenger-go (RFC-044.4 WS3a follow-up)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,10 @@
 name: Publish Docker Image
+# Self-contained build + sign for challenger-go. This repo is public and cannot call
+# the private actions-workflows reusables, so the build is inlined here (faithful port
+# of docker-build-and-publish.yaml for challenger-go) and signing runs via the local
+# sign-image.yaml. The signer is referenced as <repo>/sign-image.yaml@main so the
+# cosign keyless SAN is sign-image.yaml@refs/heads/main, matching the Kyverno
+# verify-chronicle-release-images enforce identity regardless of the build trigger.
 on:
   workflow_call:
   workflow_dispatch:
@@ -10,11 +16,70 @@ on:
         default: ''
 jobs:
   build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      tags: ${{ steps.metadata.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
+        with:
+          images: ghcr.io/chronicleprotocol/challenger-go
+          tags: |
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+        with:
+          install: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          file: Dockerfile
+          build-args: |
+            APP_NAME=challenger-go
+            APP_VERSION=${{ inputs.version != '' && inputs.version || steps.metadata.outputs.version }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  sign:
+    name: Sign published image
+    needs: build-and-push
+    if: ${{ needs.build-and-push.outputs.digest != '' }}
     permissions:
       contents: read
       id-token: write
       packages: write
-    uses: chronicleprotocol/actions-workflows/.github/workflows/docker-build-and-publish.yaml@main
+    # Pinned @main so the keyless SAN is sign-image.yaml@refs/heads/main (matches the
+    # Kyverno enforce identity), invariant of the calling ref.
+    uses: chronicleprotocol/challenger/.github/workflows/sign-image.yaml@main
     with:
-      application: challenger-go
-      version: ${{ inputs.version }}
+      digest: ${{ needs.build-and-push.outputs.digest }}
+      tags: ${{ needs.build-and-push.outputs.tags }}


### PR DESCRIPTION
## What

Replaces `docker.yml`'s delegation to the private `docker-build-and-publish.yaml`
reusable with an in-repo build (faithful port for `challenger-go`) plus this repo's
embedded signer.

## Why

This repo is public; it cannot call the private `actions-workflows` reusables, so the
old `docker.yml` (which delegated the entire build+publish+sign to
`docker-build-and-publish.yaml@main`) was broken on public and could not run at all.

The new workflow:
- builds + pushes `ghcr.io/chronicleprotocol/challenger-go` inline (same actions, SHA
  pins, build-args `APP_NAME`/`APP_VERSION`, platforms, and metadata tagging as the
  private reusable used for this app), then
- signs via `chronicleprotocol/challenger/.github/workflows/sign-image.yaml@main`. The
  `@main` pin makes the keyless SAN `sign-image.yaml@refs/heads/main`, matching the
  Kyverno `verify-chronicle-release-images` enforce identity.

No behavior change to the produced image (same Dockerfile, args, platforms); only the
build/sign now run in-repo instead of via the unreachable private reusable.

## Test plan

- [ ] `workflow_dispatch` with a `version`: confirm `challenger-go:<version>` + `:sha-...`
      are built/pushed and signed.
- [ ] `cosign verify ghcr.io/chronicleprotocol/challenger-go@<digest>` against
      `.../challenger/.github/workflows/sign-image.yaml@refs/heads/main` passes.
- [ ] Pod admission of the new image is allowed by the enforce IVP.
